### PR TITLE
fixes template by removing polyglossia

### DIFF
--- a/cheat-sheet.tex
+++ b/cheat-sheet.tex
@@ -190,20 +190,10 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 $if(lang)$
-\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
-$if(babel-newcommands)$
-  $babel-newcommands$
-$endif$
-\else
-  % load polyglossia as late as possible as it *could* call bidi if RTL lang (e.g. Hebrew or Arabic)
-  \usepackage{polyglossia}
-  \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
-$for(polyglossia-otherlangs)$
-  \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
-$endfor$
-\fi
-$endif$
+\usepackage[$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+% get rid of language-specific shorthands (see pandoc #6817):
+\let\LanguageShortHands\languageshorthands
+\def\languageshorthands#1{}$endif$
 $if(dir)$
 \ifxetex
   % load bidi as late as possible as it modifies e.g. graphicx


### PR DESCRIPTION
This PR fixes the `polyglossia` error 

```
! Argument of \str_uppercase:n has an extra }.
<inserted text>
                \par
l.136   \setmainlanguage[]{}
```

as mentioned [here](https://github.com/jgm/pandoc/pull/7562) and [here](https://github.com/Wandmalfarbe/pandoc-latex-template/issues/278)