### PR TITLE
Add `make print` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all clean default print
+.SILENT: print
 
 default: all
 
@@ -57,12 +58,15 @@ PANDOC_PDF_FLAGS = \
 	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $@ $*.yml $<
 
 print:
+	# replacing the linkcolor and adding other colors into the yml file,
+	# calling it <file>.yml_print and using it to create the printer friendly file.
 	$(foreach file, $(SOURCES_YML), \
-	echo Creating printer friendly pdf for $(patsubst %.yml, %, $(file)); \
-	awk '/linkcolor:/{gsub(/blue/, "black")};/urlcolor:/{gsub(/blue/, "black")};/monospacecolor:/{gsub(/blue/, "black")};{print}' $(file) > $(file)_print ; \
-	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %_print.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
+		echo Creating printer friendly pdf for $(patsubst %.yml, %, $(file)); \
+		sed 's/linkcolor: [A-z]*/\nlinkcolor: black\nurlcolor: black\nmonospacecolor: black/' $(file) > $(file)_print ; \
+		$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %_print.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
+		echo File $(patsubst %.yml, %_print.pdf, $(file)) created; \
 	)\
-	echo Cleaning up ...
+	# removing the printer friendly yml file
 	rm *.yml_print
 
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ print:
 	$(foreach file, $(SOURCES_YML), \
 	echo Creating printer friendly pdf for $(patsubst %.yml, %, $(file)); \
 	awk '/linkcolor:/{gsub(/blue/, "black")};/urlcolor:/{gsub(/blue/, "black")};/monospacecolor:/{gsub(/blue/, "black")};{print}' $(file) > $(file)_print ; \
-	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
+	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %_print.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
 	)\
 	echo Cleaning up ...
 	rm *.yml_print

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: all clean default
+.PHONY: all clean default print
 
 default: all
 
 SOURCES_DOT = $(wildcard *.dot)
 SOURCES_MD = $(wildcard *-cheat-sheet.md)
+SOURCES_YML = $(wildcard *-cheat-sheet.yml)
 
 OBJECTS_DOT_SVG = $(SOURCES_DOT:.dot=.svg)
 OBJECTS_HTML = $(SOURCES_MD:.md=.html)
@@ -54,6 +55,16 @@ PANDOC_PDF_FLAGS = \
 
 %.tex: %.md %.yml cheat-sheet.tex
 	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $@ $*.yml $<
+
+print:
+	$(foreach file, $(SOURCES_YML), \
+	echo Creating printer friendly pdf for $(patsubst %.yml, %, $(file)); \
+	awk '/linkcolor:/{gsub(/blue/, "black")};/urlcolor:/{gsub(/blue/, "black")};/monospacecolor:/{gsub(/blue/, "black")};{print}' $(file) > $(file)_print ; \
+	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
+	)\
+	echo Cleaning up ...
+	rm *.yml_print
+
 
 clean:
 	rm -f $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ OBJECTS_HTML = $(SOURCES_MD:.md=.html)
 OBJECTS_PDF = $(SOURCES_MD:.md=.pdf)
 OBJECTS_TEX = $(SOURCES_MD:.md=.tex)
 
+META_URL_COLOR = "urlcolor"
+META_LINK_COLOR = "linkcolor"
+META_MONO_COLOR = "monospacecolor"
+PRINT_COLOR = "black"
+
 OBJECTS = \
 	$(OBJECTS_DOT_SVG) \
 	$(OBJECTS_HTML) \
@@ -45,6 +50,11 @@ PANDOC_PDF_FLAGS = \
 	$(PANDOC_TEX_FLAGS) \
 	--pdf-engine=$(PANDOC_PDF_ENGINE) \
 
+PANDOC_PRINT_FLAGS = \
+    --metadata=$(META_LINK_COLOR):$(PRINT_COLOR) \
+    --metadata=$(META_MONO_COLOR):$(PRINT_COLOR) \
+    --metadata=$(META_URL_COLOR):$(PRINT_COLOR) \
+
 %.svg: %.dot
 	dot -Tsvg -o $@ $<
 
@@ -58,17 +68,10 @@ PANDOC_PDF_FLAGS = \
 	$(PANDOC) $(PANDOC_TEX_FLAGS) -o $@ $*.yml $<
 
 print:
-	# replacing the linkcolor and adding other colors into the yml file,
-	# calling it <file>.yml_print and using it to create the printer friendly file.
 	$(foreach file, $(SOURCES_YML), \
 		echo Creating printer friendly pdf for $(patsubst %.yml, %, $(file)); \
-		sed 's/linkcolor: [A-z]*/\nlinkcolor: black\nurlcolor: black\nmonospacecolor: black/' $(file) > $(file)_print ; \
-		$(PANDOC) $(PANDOC_TEX_FLAGS) -o $(patsubst %.yml, %_print.pdf, $(file)) $(file)_print $(patsubst %.yml, %.md, $(file)); \
-		echo File $(patsubst %.yml, %_print.pdf, $(file)) created; \
+		$(PANDOC) $(PANDOC_TEX_FLAGS) $(PANDOC_PRINT_FLAGS) -o $(patsubst %.yml, %_print.pdf, $(file)) $(file) $(patsubst %.yml, %.md, $(file)); \
 	)\
-	# removing the printer friendly yml file
-	rm *.yml_print
-
 
 clean:
 	rm -f $(OBJECTS)

--- a/cheat-sheet.tex
+++ b/cheat-sheet.tex
@@ -229,9 +229,13 @@ $endif$
 \date{$date$}
 
 \usepackage{multicol}
-
+$if(monospacecolor)$
+\let\oldtexttt\texttt
+\renewcommand{\texttt}[1]{{\color{$monospacecolor$}{\oldtexttt{#1}}}}
+$else$
 \let\oldtexttt\texttt
 \renewcommand{\texttt}[1]{{\color{blue}{\oldtexttt{#1}}}}
+$endif$
 
 $if(sectionbg)$
 \setkomafont{section}{\mysection}

--- a/example-variables.yml
+++ b/example-variables.yml
@@ -11,6 +11,8 @@ keywords:
 
 # highlighting increases readability
 linkcolor: blue
+urlcolor: blue
+monospacecolor: blue
 
 # these LaTeX variables fit as much content on as few pages as possible
 documentclass: scrartcl

--- a/example-variables.yml
+++ b/example-variables.yml
@@ -11,8 +11,6 @@ keywords:
 
 # highlighting increases readability
 linkcolor: blue
-urlcolor: blue
-monospacecolor: blue
 
 # these LaTeX variables fit as much content on as few pages as possible
 documentclass: scrartcl


### PR DESCRIPTION
This PR fixes #1 

This PR adds a new `print` target, that makes all monospaced fonts, url and links black. In order to be able to make the monospaced font also printer friendly, a new yml property has been introduced: `monospacecolor` to set the color of the `texttt` command.

The `print` command replaces the colors of the above mentioned yml properties to `black` with overriding the values in the `yml`-file with the `--metadata` command.